### PR TITLE
Add gsj_numerical_png_terrain_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ https://deton.github.io/CzmlFirstPersonPlayer/?tileset=google3dtile&czmlurl=http
   * それ以外の場合: 3D tileset URL。複数回指定した場合は全て読み込む。
   * (default): https://assets.cms.plateau.reearth.io/assets/aa/ecf312-95c2-4e24-8351-642f27e447b6/13100_tokyo23-ku_2022_3dtiles_1_1_op_bldg_13101_chiyoda-ku_lod1/tileset.json
   * (備考): この他、CZMLファイル内で指定したtilesetも読み込まれます。
+* tilesetHeightOffset: tilesetの高さ調整用のオフセット値。
+  * (default): 0
 * height: terrainからの視点の高さ。CZML内のmodel.heightReferenceがCLAMPで始まる場合、terrainに対してこの固定値を足した値を視点の高さとして使う。
   * (default): 2
   * (備考): (JavaScript ConsoleでHEIGHT_OFFSETを変更することで調整可能)

--- a/docs/ExtendedNumericalPngTerrainProvider.js
+++ b/docs/ExtendedNumericalPngTerrainProvider.js
@@ -1,0 +1,540 @@
+//**************************************************************************
+//ExtendedNumericalPngTerrainProvider
+//NumericalPngTerrainProvider拡張
+//タイル欠損対応・無効値ピクセル対応・ジオイド高対応
+//TerrainProvider extend NumericalPngTerrainProvider
+//resolved lack of tiles, invalid pixels, geoid height
+/*!
+ *	@name	: ExtendedNumericalPngTerrainProvider
+ *	@description	: Terrain provider for numerical png tile of elevation extended.
+ *	@version	: 2.0.0
+ *	@released	: 20231120
+ *	@required	: Cesium, NumericalPngTerrainProvider
+ *	@author	: Kaoru KITAO
+ *	@email	: kaoru@kitao.net
+ *      @copyright      : 2023, National Institute of Advanced Industrial Science and Technology (AIST)
+ *      @license        : Apache License, Version 2.0
+*/
+
+//******************************************************************************
+//ExtendedNumericalPngTerrainProviderクラス
+class ExtendedNumericalPngTerrainProvider extends NumericalPngTerrainProvider {
+	//**************************************************************************
+	//追加のメンバ変数
+	//--------------------------------------------------------------------------
+	//ジオイド高タイルURLテンプレート
+	geoidUrl;
+	//--------------------------------------------------------------------------
+	//ジオイド高を反映するか否か
+	useGeoid;
+	//--------------------------------------------------------------------------
+	//ジオイド高のピクセル値をメートル単位に変換する係数
+	geoidHeightScale;
+	//--------------------------------------------------------------------------
+	//探索ズームレベル設定（標高とジオイド高）
+	//日本の陸域全部を保持する最大ズームレベル
+	japanCoveredLevel;
+	geoidJapanCoveredLevel;
+
+	//**************************************************************************
+	//コンストラクタ
+	constructor ( opts ) {
+		//----------------------------------------------------------------------
+		//継承元コンストラクタの実行
+		super( opts );
+		//----------------------------------------------------------------------
+		//追加オプションをメンバ変数に登録
+		//ジオイド高タイルURLをテンプレートの指定
+		this.geoidUrl	= Cesium.defaultValue(
+			opts.geoidUrl,
+			'https://tiles.gsj.jp/tiles/elev/gsigeoid/{z}/{y}/{x}.png'
+		);
+		//デフォルトはジオイド高を反映しない
+		this.useGeoid	= Cesium.defaultValue( opts.useGeoid, false );
+		//ジオイド高メートル換算係数
+		this.geoidHeightScale	= Cesium.defaultValue(
+			opts.geoidHeightScale,
+			0.0001
+		);
+		//探索ズームレベル設定（標高）
+		this.japanCoveredLevel	= Cesium.defaultValue(
+			opts.japanCoveredLevel,
+			14
+		);
+		//探索ズームレベル設定（ジオイド高）
+		this.geoidJapanCoveredLevel	= Cesium.defaultValue(
+			opts.geoidJapanCoveredLevel,
+			8
+		);
+	}
+
+	//**************************************************************************
+	//既存メソッドの上書き（requestTileGeometryから呼ばれる）
+	//標高タイルに加えてジオイド高タイルを加算する可能性があるためその過程を追加
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+		@return	mixed	: QuantizedMeshTerrainData or HeightmapTerrainData instance
+	*/
+	async createTileGeometry ( x, y, level ) {
+		//----------------------------------------------------------------------
+		//合成canvasを作る処理が標高とジオイド高で必要となるためプロミス配列を作る
+		//標高処理は必須であるためデフォルトで追加
+		const promises	= [
+			this.createSynthesizedTileExtended( x, y, level, 'elevation' )
+		];
+		//ジオイド高処理はコンストラクタ引数で指定
+		if ( this.useGeoid ) {
+			//ジオイド高を加える場合はジオイド高処理を登録
+			promises.push( this.createSynthesizedTileExtended( x, y, level, 'geoid' ));
+		} else {
+			//ジオイド高を加えない場合はfalseを返すプロミスを登録
+			promises.push( Promise.resolve( false ));
+		}
+		//----------------------------------------------------------------------
+		//2つのプロミス結果を待って処理
+		return await Promise.all( promises ).then(
+			( values ) => {
+				//結果の状態で分岐
+				if (
+					!( values[0] instanceof HTMLCanvasElement )
+					&& !( values[1] instanceof HTMLCanvasElement )
+				) {
+					//標高とジオイド高の両方とも取得できなかった場合は空のheightmapを返す
+					return this.emptyHeightmap();
+				} else if (
+					values[0] instanceof HTMLCanvasElement
+					&& values[1] instanceof HTMLCanvasElement
+				) {
+					//標高とジオイド高の両方とも取得できた場合
+					const heightScales	= [
+						this.heightScale,
+						this.geoidHeightScale
+					];
+					//terrainを作る
+					const terrain	= values.map(( value, index ) => {
+						//それぞれで処理
+						//imageDataを取得してバイリニア単位に応じて処理を振り分けて結果を返す
+						const imageData	= value.getContext( '2d' ).getImageData(
+							0, 0, value.width, value.height
+						);
+						return value.unitSize === 1
+						? this.imageDataToTerrain( imageData, heightScales[ index ] )
+						: this.imageDataToTerrainBilineard(
+							imageData, heightScales[ index ], value.unitSize
+						);
+					}).reduce(( acc, cur ) => {
+						//両方の結果を合算して返す
+						return acc.map(( value, index ) => {
+							return value + cur[index];
+						});
+					});
+					//得られたterrainを量子化して返す
+					return this.createQuantizedMeshData( x, y, level, terrain );
+				} else if ( values[0] instanceof HTMLCanvasElement ) {
+					//標高のみ取得できた場合
+					//imageDataを取得してバイリニア単位に応じて分岐処理して結果を返す
+					const imageData	= values[0].getContext( '2d' ).getImageData(
+						0, 0, values[0].width, values[0].height
+					);
+					const terrain	= values[0].unitSize === 1
+					? this.imageDataToTerrain( imageData, this.heightScale )
+					: this.imageDataToTerrainBilineard(
+						imageData, this.heightScale, values[0].unitSize
+					);
+					//得られたterrainを量子化して返す
+					return this.createQuantizedMeshData( x, y, level, terrain );
+				} else {
+					//ジオイド高のみ取得できた場合
+					//imageDataを取得してバイリニア単位に応じて分岐処理して結果を返す
+					const imageData	= values[1].getContext( '2d' ).getImageData(
+						0, 0, values[1].width, values[1].height
+					);
+					const terrain	= values[1].unitSize === 1
+					? this.imageDataToTerrain( imageData, this.geoidHeightScale )
+					: this.imageDataToTerrainBilineard(
+						imageData, this.geoidHeightScale, values[1].unitSize
+					);
+					//得られたterrainを量子化して返す
+					return this.createQuantizedMeshData( x, y, level, terrain );
+				}
+			}
+		);
+	}
+
+	//**************************************************************************
+	//既存メソッドの拡張（createTileGeometryから呼ばれる）
+	//第3引数typeを追加し、標高とジオイド高で処理を分岐可能となるよう変更
+	//主、右、下、右下の合成タイルを作る
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+		@param	string	: 'elevation' or 'geoid'
+		@return	mixed	: canvas or false
+	*/
+	async createSynthesizedTileExtended ( x, y, level, type ) {
+		//----------------------------------------------------------------------
+		//タイルURLテンプレートと探索で使用するメソッドを決める
+		const parameters	= type === 'elevation'
+		? { url: this.url, method: 'seekElevationTile' }
+		: type === 'geoid'
+		? { url: this.geoidUrl, method: 'seekGeoidTile' }
+		: false;
+		//----------------------------------------------------------------------
+		//実際にはfalseにならないのでこの処理は呼ばれない
+		if ( parameters === false ) {
+			throw new Error( 'Invalid type specified.' );
+		}
+		//----------------------------------------------------------------------
+		//主、右、下、右下のタイルを取得するプロミス配列を作る
+		const promises	= [
+			[ 0, 0 ], [ 1, 0 ], [ 0, 1 ], [ 1, 1 ]
+		].map(( values ) => {
+			//ズームレベル0と右端タイルの場合を考慮して取得タイルのx座標を決める
+			const tileX	= level === 0
+			? 0
+			: x + values[0] < 2 ** level
+			? x + values[0]
+			: 0;
+			//タイル取得プロミスを返す（seekElevationTileまたはseekGeoidTile）
+			return this[ parameters.method ](
+				tileX, y + values[1], level, parameters.url
+			);
+		});
+		//----------------------------------------------------------------------
+		//プロミス配列の処理を待って結果を返す
+		return await Promise.all( promises ).then(
+			( values ) => {
+				//主タイル取得成否で分岐
+				if (
+					values[0] instanceof HTMLImageElement
+					|| values[0] instanceof HTMLCanvasElement
+				) {
+					//主タイル（Canvas）取得成功時
+					//canvasを作ってcontextを取得
+					const canvas	= document.createElement( 'canvas' );
+					canvas.width	= canvas.height	= this.tileWidth + 1;
+					const context	= canvas.getContext( '2d' );
+					//context取得成功時のみ処理
+					if ( context instanceof CanvasRenderingContext2D ) {
+						//4つのタイルの取得結果を走査して処理
+						values.forEach(( value, index ) => {
+							//タイル貼付け位置を決める
+							const x	= ( index % 2 ) * this.tileWidth;
+							const y	= Math.floor( index / 2 ) * this.tileWidth;
+							//タイル取得成功時のみ貼り付け
+							if (
+								value instanceof HTMLImageElement
+								|| value instanceof HTMLCanvasElement
+							) {
+								context.drawImage( value, x, y );
+							}
+						});
+					}
+					canvas.unitSize	= values[0].unitSize;
+					//canvasを返す
+					return canvas;
+				} else {
+					//主タイル取得失敗時
+					//falseを返す
+					return false;
+				}
+			}
+		);
+	}
+
+	//**************************************************************************
+	//標高タイルを探索する
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+		@return	mixed	: canvas or false
+	*/
+	async seekElevationTile ( x, y, level ) {
+		//----------------------------------------------------------------------
+		//結果を格納するcanvasを作ってcontextを取得
+		const canvas	= document.createElement( 'canvas' );
+		canvas.width	= canvas.height	= this.tileWidth;
+		const context	= canvas.getContext( '2d' );
+		//----------------------------------------------------------------------
+		//タイルが取得できていないことを示すフラグを用意する
+		canvas.retrieved	= false;
+		//----------------------------------------------------------------------
+		//取得対象ズームレベルの初期値（ここから1ずつ減らしていく）
+		let seekLevel	= level;
+		//----------------------------------------------------------------------
+		//タイルが取得できていない場合はループ
+		while ( canvas.retrieved === false ) {
+			//取得すべきタイル座標を決めてタイルを取得する
+			const seekedCoords	= this.getSeekTileCoords( seekLevel, x, y, level );
+			const tile	= await this.fetchTile(
+				seekedCoords.x,
+				seekedCoords.y,
+				seekedCoords.level,
+				this.url
+			);
+			//取得できた場合のみ処理
+			if ( tile instanceof HTMLImageElement ) {
+				//元のズームレベルと取得したタイルのズームレベルで分岐
+				if ( seekLevel === level ) {
+					//元のズームレベルでタイルを取得できた場合はそのまま貼り付け
+					context.drawImage( tile, 0, 0 );
+				} else {
+					//低ズームレベルを取得した場合
+					//切り出す原点とサイズを決める
+					const origin	= this.getCropOrigin(
+						seekLevel, x, y, level
+					);
+					const cropSize	= Math.max(
+						1, this.tileWidth / ( 2 ** ( level - seekLevel ))
+					);
+					//切り出す
+					const cropped	= this.cropTile( tile, origin, cropSize );
+					//canvasを埋める
+					this.fillFlat( context, cropped );
+				}
+				//タイル取得完了のフラグを立てる
+				canvas.retrieved	= true;
+				//バイリニア単位をセット（この値+1のサイズでバイリニアする）
+				canvas.unitSize	= Math.min(
+					this.tileWidth, 2 ** ( level - seekLevel )
+				);
+			}
+			//次の探索ズームレベルを決める
+			seekLevel	-= 1;
+			//ズームレベルが既定値未満の場合は処理終了
+			if ( seekLevel < this.japanCoveredLevel ) {
+				break;
+			}
+		}
+		//----------------------------------------------------------------------
+		//結果を返す
+		return canvas.retrieved ? canvas : false;
+	}
+
+	//**************************************************************************
+	//ジオイド高タイルを探索する
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+		@return	mixed	: canvas or false
+	*/
+	async seekGeoidTile ( x, y, level ) {
+		//----------------------------------------------------------------------
+		//結果を格納するcanvasを作ってcontextを取得
+		const canvas	= document.createElement( 'canvas' );
+		canvas.width	= canvas.height	= this.tileWidth;
+		const context	= canvas.getContext( '2d' );
+		//----------------------------------------------------------------------
+		//取得対象ズームレベルの初期値（探索は1回のみ）
+		let seekLevel	= Math.min( level, this.geoidJapanCoveredLevel );
+		//----------------------------------------------------------------------
+		//取得すべきタイル座標を決めてタイルを取得する
+		const seekedCoords	= this.getSeekTileCoords( seekLevel, x, y, level );
+		const tile	= await this.fetchTile(
+			seekedCoords.x,
+			seekedCoords.y,
+			seekedCoords.level,
+			this.geoidUrl
+		);
+		//----------------------------------------------------------------------
+		//取得できた場合のみ処理
+		if ( tile instanceof HTMLImageElement ) {
+			//元のズームレベルと取得したタイルのズームレベルで分岐
+			if ( seekLevel === level ) {
+				//元のズームレベルでタイルを取得できた場合はそのまま貼り付け
+				context.drawImage( tile, 0, 0 );
+			} else {
+				//低ズームレベルを取得した場合
+				//切り出す原点とサイズを決める
+				const origin	= this.getCropOrigin( seekLevel, x, y, level );
+				const cropSize	= Math.max(
+					1, this.tileWidth / ( 2 ** ( level - seekLevel ))
+				);
+				//切り出す
+				const cropped	= this.cropTile( tile, origin, cropSize );
+				//canvasを埋める
+				this.fillFlat( context, cropped );
+			}
+			//バイリニア単位をセット（この値+1のサイズでバイリニアする）
+			canvas.unitSize	= Math.min(
+				this.tileWidth, 2 ** ( level - seekLevel )
+			);
+			//canvasを返す
+			return canvas;
+		} else {
+			//falseを返す
+			return false;
+		}
+	}
+
+	//**************************************************************************
+	//切り出すタイルのタイル座標を決める
+	/*
+		@param	number	: level coordinate for actual retrieving tile
+		@param	number	: x coordinate for originally tile
+		@param	number	: y coordinate for originally tile
+		@param	number	: level coordinate for originally tile
+		@return	object	: x, y, level coordinates
+	*/
+	getSeekTileCoords ( seekTileLevel, x, y, level ) {
+		const unitSize	= 2 ** ( level - seekTileLevel );
+		const seekTileX	= Math.floor( x / unitSize );
+		const seekTileY	= Math.floor( y / unitSize );
+		return { x: seekTileX, y: seekTileY, level: seekTileLevel };
+	}
+
+	//**************************************************************************
+	//タイルからの切り出し位置（原点）を決める
+	/*
+		@param	number	: level coordinate for actual retrieving tile
+		@param	number	: x coordinate for originally tile
+		@param	number	: y coordinate for originally tile
+		@param	number	: level coordinate for originally tile
+		@return	object	: x, y coordinates
+	*/
+	getCropOrigin ( seekTileLevel, x, y, level ) {
+		const point	= {
+			x: x * this.tileWidth,
+			y: y * this.tileWidth
+		};
+		return {
+			x: Math.floor( point.x / 2 ** ( level - seekTileLevel ) % this.tileWidth ),
+			y: Math.floor( point.y / 2 ** ( level - seekTileLevel ) % this.tileWidth )
+		};
+	}
+
+	//**************************************************************************
+	//原点と大きさを指定して必要箇所を切り出す
+	/*
+		@param	element	: image
+		@param	object	: origin to crop
+		@param	number	: size to crop
+		@return	element	: canvas
+	*/
+	cropTile ( tile, origin, size ) {
+		const canvas	= document.createElement( 'canvas' );
+		canvas.width	= canvas.height	= size;
+		const context	= canvas.getContext( '2d' );
+		context.drawImage(
+			tile, origin.x, origin.y, size, size, 0, 0, size, size
+		);
+		return canvas;
+	}
+
+	//**************************************************************************
+	//フラット補間（ピクセル単純拡大）
+	//標高タイルは隣接タイルが同じズームレベルとは限らないため一旦これを使う必要あり
+	/*
+		@param	context	: to fill
+		@param	canvas	: source for filling
+	*/
+	fillFlat ( context, cropped ) {
+		const size	= context.canvas.width / cropped.width;
+		const imageData	= cropped.getContext( '2d' ).getImageData(
+			0, 0, cropped.width, cropped.height
+		);
+		for ( let y = 0; y < cropped.height; y += 1 ) {
+			for ( let x = 0; x < cropped.width; x += 1 ) {
+				const index	= y * cropped.width + x;
+				const rgba	= imageData.data.slice( index * 4, index * 4 + 4 );
+				context.fillStyle	= `rgba(${rgba.toString()})`;
+				context.fillRect( x * size, y * size, size, size );
+			}
+		}
+	}
+
+	//**************************************************************************
+	//imageDataを間引いてバイリニア補間しつつterrainに変換する
+	/*
+		@param	object	: imageData
+		@param	number	: source expanded size
+		@return	typed	: optimized terrain data
+	*/
+	imageDataToTerrainBilineard ( imageData, scale, srcInterval ) {
+		//----------------------------------------------------------------------
+		//間引き間隔
+		const dstInterval	= this.tileWidth / ( this.heightmapWidth - 1 );
+		//----------------------------------------------------------------------
+		//バイリニアで使用しうる標高（四隅）を最初に求めておく
+		const elevations	= new Float32Array(( this.tileWidth + 1 ) ** 2 );
+		for ( let y = 0, maxY = this.tileWidth + 1; y < maxY; y += srcInterval ) {
+			for ( let x = 0, maxX = this.tileWidth + 1; x < maxX; x += srcInterval ) {
+				const index	= y * ( this.tileWidth + 1 ) + x;
+				const rgba	= imageData.data.slice( index * 4, index * 4 + 4 );
+				elevations[ index ]	= this.rgbaToHeight( rgba, scale );
+			}
+		}
+		// //----------------------------------------------------------------------
+		// //terrainを決める
+		// const terrain	= [];
+		// for ( let y = 0, maxY = this.tileWidth + 1; y < maxY; y += dstInterval ) {
+		// 	//バイリニアの上座標と下座標とyの100分率
+		// 	const t	= Math.floor( y / srcInterval ) * srcInterval;
+		// 	const b	= Math.min( t + srcInterval, this.tileWidth );
+		// 	const dy	= b - t === 0 ? 0 : ( y - t ) / ( b - t );
+		// 	for ( let x = 0, maxX = this.tileWidth + 1; x < maxX; x += dstInterval ) {
+		// 		//バイリニアの左座標と右座標とxの100分率
+		// 		const l	= Math.floor( x / srcInterval ) * srcInterval;
+		// 		const r	= Math.min( l + srcInterval, this.tileWidth );
+		// 		const dx	= r - l === 0 ? 0 : ( x - l ) / ( r - l );
+		// 		//四隅の標高を求める
+		// 		const lt	= elevations[ t * ( this.tileWidth + 1 ) + l ];
+		// 		const rt	= elevations[ t * ( this.tileWidth + 1 ) + r ];
+		// 		const lb	= elevations[ b * ( this.tileWidth + 1 ) + l ];
+		// 		const rb	= elevations[ b * ( this.tileWidth + 1 ) + r ];
+		// 		//バイリニア補完した結果を格納する
+		// 		terrain.push(
+		// 			(
+		// 				( 1 - dx ) * ( 1 - dy ) * lt
+		// 			) + (
+		// 				dx * ( 1 - dy ) * rt
+		// 			) + (
+		// 				( 1 - dx ) * dy * lb
+		// 			) + (
+		// 				dx * dy * rb
+		// 			)
+		// 		);
+		// 	}
+		// }
+		//----------------------------------------------------------------------
+		//terrainを決める
+		const terrain	= new Float32Array( this.heightmapWidth ** 2 );
+		// for ( let y = 0, maxY = ( this.tileWidth + 1 ) / dstInterval; y < maxY; y += 1 ) {
+		for ( let y = 0; y < this.heightmapWidth; y += 1 ) {
+			//バイリニアの上座標と下座標とyの100分率
+			const t	= Math.floor( y * dstInterval / srcInterval ) * srcInterval;
+			const b	= Math.min( t + srcInterval, this.tileWidth );
+			const dy	= b - t === 0 ? 0 : ( y * dstInterval - t ) / ( b - t );
+			// for ( let x = 0, maxX = ( this.tileWidth + 1 ) / dstInterval; x < maxX; x += 1 ) {
+			for ( let x = 0; x < this.heightmapWidth; x += 1 ) {
+				//バイリニアの左座標と右座標とxの100分率
+				const l	= Math.floor( x * dstInterval / srcInterval ) * srcInterval;
+				const r	= Math.min( l + srcInterval, this.tileWidth );
+				const dx	= r - l === 0 ? 0 : ( x * dstInterval - l ) / ( r - l );
+				//四隅の標高を求める
+				const lt	= elevations[ t * ( this.tileWidth + 1 ) + l ];
+				const rt	= elevations[ t * ( this.tileWidth + 1 ) + r ];
+				const lb	= elevations[ b * ( this.tileWidth + 1 ) + l ];
+				const rb	= elevations[ b * ( this.tileWidth + 1 ) + r ];
+				//バイリニア補完した結果を格納する
+				terrain[ y * this.heightmapWidth + x ]	= (
+					( 1 - dx ) * ( 1 - dy ) * lt
+				) + (
+					dx * ( 1 - dy ) * rt
+				) + (
+					( 1 - dx ) * dy * lb
+				) + (
+					dx * dy * rb
+				);
+			}
+		}
+		//----------------------------------------------------------------------
+		//結果を返す
+		return terrain;
+	}
+}

--- a/docs/NumericalPngTerrainProvider.js
+++ b/docs/NumericalPngTerrainProvider.js
@@ -1,0 +1,733 @@
+//******************************************************************************
+//NumericalPngTerrainProvider
+//標高数値PNGタイル用TerrainProvider（隣接タイルギャップ対応・法線ベクトル対応）
+//Terrain provider for numerical png tile of elevation
+//resolved tile boundary joint problem, normal vector
+//using decimated grid height map not rtin
+/*!
+ *	@name	: NumericalPngTerrainProvider
+ *	@description	: Terrain provider for numerical png tile of elevation.
+ *	@version	: 2.0.0
+ *	@released	: 20231120
+ *	@required	: Cesium
+ *	@author	: Kaoru KITAO
+ *	@email	: kaoru@kitao.net
+ *      @copyright      : 2023, National Institute of Advanced Industrial Science and Technology (AIST)
+ *      @license        : Apache License, Version 2.0
+*/
+
+//******************************************************************************
+//タイルシステムのキャッシングシステム
+//TileCacherクラス
+class TileCacher {
+	//**************************************************************************
+	//メンバ変数
+	caches	= [];	//キャッシュ格納
+	size;	//キャッシュ上限数
+
+	//**************************************************************************
+	//コンストラクタ
+	/*
+		@param	number	: count for tiles to cache
+	*/
+	constructor ( size ) {
+		//----------------------------------------------------------------------
+		//キャッシュを格納する配列の初期化とキャッシュの上限を設定
+		this.size	= Cesium.defaultValue( size, 256 );
+	}
+
+	//**************************************************************************
+	//タイル座標を指定してキャッシュを取得
+	/*
+		@param	number	: x coordinate of tile
+		@param	number	: y coordinate of tile
+		@param	number	: level coordinate of tile
+		@return	mixed	: object or undefined
+	*/
+	get ( x, y, level ) {
+		//----------------------------------------------------------------------
+		//タイル座標が合致するデータを探し、見つかればタイムスタンプを更新する
+		const match	= this.caches.find(( element ) => {
+			const match	= element.x === x
+			&& element.y === y
+			&& element.level === level;
+			if ( match ) {
+				element.timestamp	= Date.now();
+			}
+			return match;
+		});
+		//----------------------------------------------------------------------
+		//結果を返す：処理中に要素が破棄される可能性があるため多重チェック
+		return match === void( 0 )
+		? void( 0 )
+		: typeof match === 'object' ?? !Array.isArray( match )
+		? void( 0 )
+		: match.value === void( 0 )
+		? void( 0 )
+		: structuredClone( match.value );
+	}
+
+	//**************************************************************************
+	//キャッシュを登録
+	/*
+		@param	number	: x coordinate of tile
+		@param	number	: y coordinate of tile
+		@param	number	: level coordinate of tile
+		@param	mixed	: value for tile coordinates
+		@return	object	: registered object
+	*/
+	add ( x, y, level, value ) {
+		//----------------------------------------------------------------------
+		//タイムスタンプを決める
+		const timestamp	= Date.now();
+		//----------------------------------------------------------------------
+		//タイル座標が合致する要素の取得を試みる
+		const element	= this.caches.find(( element ) => {
+			//タイル座標の合致を調べる
+			const match	= element.x === x
+			&& element.y === y
+			&& element.level === level;
+			//タイル座標の合致があれば値とタイムスタンプを上書きする
+			if ( match ) {
+				element.timestamp	= timestamp;
+				element.value	= value;
+			}
+			//合致の結果を返す
+			return match;
+		});
+		//----------------------------------------------------------------------
+		//合致する要素がない場合は値を登録する
+		if ( element === void( 0 )) {
+			this.caches.push({
+				x, y, level, value, timestamp,
+			});
+		}
+		//----------------------------------------------------------------------
+		//キャッシュを掃除する
+		this.clean();
+		//----------------------------------------------------------------------
+		//参照を返す
+		return this;
+	}
+
+	//**************************************************************************
+	//キャッシュを掃除
+	/*
+		@return	this
+	*/
+	clean () {
+		//----------------------------------------------------------------------
+		//キャッシュをタイムスタンプの降順で並べて指定件数分以降の要素を破棄
+		this.caches.sort(( a, b ) => {
+			return b.timestamp - a.timestamp;
+		}).splice( this.size );
+		//----------------------------------------------------------------------
+		//参照を返す
+		return this;
+	}
+};
+
+//******************************************************************************
+//NumericalPngTerrainProviderクラス
+class NumericalPngTerrainProvider {
+	//**************************************************************************
+	//メンバ変数
+	//--------------------------------------------------------------------------
+	//初期値固定
+	hasWaterMask		= false;
+	ready				= true;
+	readyPromise		= Promise.resolve( true );
+	//--------------------------------------------------------------------------
+	//コンストラクタで設定（初期値あり）
+	url;
+	credit;
+	maximumLevel;
+	ellipsoid;
+	tileWidth;
+	heightScale;
+	heightInvalidValue;
+	hasVertexNormals;
+	heightmapWidth;
+	zeroRectangleLimit;
+	//--------------------------------------------------------------------------
+	//コンストラクタで生成
+	tilingScheme;
+	availability;
+	errorEvent;
+	indices;
+	//--------------------------------------------------------------------------
+	//コンストラクタで生成（キャッシュ）
+	cacheObj;
+
+	//**************************************************************************
+	//コンストラクタ
+	/*
+		@param	mixed	: undefined or object, see NumericalPngTerrainProviderOpts
+					{
+						url			: tile url template
+						credit		: string or Cesium Credit instance
+						ellipsoid	: Cesium Ellipsoid instance
+						tileWidth	: tile width
+						heightScale	: scale for pixel value to meter
+						maximumLevel	: available max zoom level of tiles
+						heightInvalidValue	: invalid value
+						useVertexNormals	: use or not vertex normals
+						heightmapWidth	: reduced height map width
+						zeroRectangleLimit	: tile radian max size to calculate
+						cacheSize	: number of caching tiles
+					}
+	*/
+	constructor ( options ) {
+		//----------------------------------------------------------------------
+		//引数の整理
+		const opts	= Cesium.defaultValue( options, {});
+		//----------------------------------------------------------------------
+		//メンバ変数初期値設定
+		this.url	= Cesium.defaultValue(
+			// opts.url, 'https://tiles.gsj.jp/tiles/elev/mixed/{z}/{y}/{x}.png'
+			opts.url, 'https://tiles.gsj.jp/tiles/elev/land/{z}/{y}/{x}.png'
+		);
+		this.credit	= typeof opts.credit === 'string'
+		? new Cesium.Credit( opts.credit )
+		: opts.credit instanceof Cesium.Credit
+		? opts.credit
+		: new Cesium.Credit([
+			'<a href="https://gbank.gsj.jp/seamless/elev/">',
+			'Seamless Elevation Tiles',
+			'</a>'
+		].join( '' ));
+		this.ellipsoid		= Cesium.defaultValue( opts.ellipsoid, Cesium.Ellipsoid.WGS84 );
+		this.tileWidth		= Cesium.defaultValue( opts.tileWidth, 256 );
+		this.heightScale	= Cesium.defaultValue( opts.heightScale, 0.01 );
+		this.maximumLevel	= Cesium.defaultValue( opts.maximumLevel, 14 );
+		this.heightInvalidValue	= opts.heightInvalidValue === void( 0 )
+		? -8388608
+		: opts.heightInvalidValue === null
+		? 0
+		: opts.heightInvalidValue;
+		this.hasVertexNormals	= Cesium.defaultValue( opts.useVertexNormals, false );
+		this.heightmapWidth	= Cesium.defaultValue( opts.heightmapWidth, 65 );
+		// this.zeroRectangleLimit	= Cesium.defaultValue( opts.zeroRectangleLimit, Math.PI / 180 * 0.5 );
+		this.zeroRectangleLimit	= Cesium.defaultValue( opts.zeroRectangleLimit, false );
+		const cacheSize		= Cesium.defaultValue( opts.cacheSize, 100 );
+		//----------------------------------------------------------------------
+		//標高マップの頂点インデックスを16ビットに抑える
+		if ( this.heightmapWidth > 256 ) {
+			throw new Error( '"heightmapWidth" must be equal or less than 256.' );
+		}
+		//----------------------------------------------------------------------
+		//メンバ変数インスタンス生成（初期値設定後に決まる）
+		this.tilingScheme	= new Cesium.WebMercatorTilingScheme({
+			numberOfLevelZeroTilesX: 1,
+			numberOfLevelZeroTilesY: 1,
+			ellipsoid: this.ellipsoid,
+		});
+		this.availability	= new Cesium.TileAvailability(
+			this.tilingScheme,
+			this.maximumLevel
+		);
+		this.errorEvent	= new Cesium.Event();
+		this.errorEvent.addEventListener( console.log, this );
+		//----------------------------------------------------------------------
+		//キャッシュ管理インスタンス
+		this.cacheObj	= new TileCacher( cacheSize );
+		//----------------------------------------------------------------------
+		//標高マップの各種インデックスを生成しておく（全タイル共通）
+		this.indices	= this.createIndices( this.heightmapWidth );
+	}
+
+	//**************************************************************************
+	//標高マップジオメトリの頂点番号を整理する
+	/*
+		@param	number	: height map width
+		@return	object	: triangle vertex indices object
+	*/
+	createIndices ( heightmapWidth ) {
+		//----------------------------------------------------------------------
+		//結果を格納するオブジェクトを用意
+		const indices	= {
+			all: new Uint16Array(( heightmapWidth - 1 ) ** 2 * 6 ),
+			north: [],
+			south: [],
+			west: [],
+			east: []
+		}
+		//----------------------------------------------------------------------
+		//全体用
+		//1行目のジオメトリ頂点番号を整理
+		const rowIndices	= new Uint16Array(( heightmapWidth - 1 ) * 6 );
+		for ( let x = 0; x < heightmapWidth - 1; x ++ ) {
+			rowIndices[ x * 6 + 0 ]	= x;
+			rowIndices[ x * 6 + 1 ]	= x + heightmapWidth + 1;
+			rowIndices[ x * 6 + 2 ]	= x + 1;
+			rowIndices[ x * 6 + 3 ]	= x;
+			rowIndices[ x * 6 + 4 ]	= x + heightmapWidth;
+			rowIndices[ x * 6 + 5 ]	= x + heightmapWidth + 1;
+		}
+		//1行目の頂点番号に幅ピクセル数を加算して順次登録
+		for ( let y = 0; y < heightmapWidth - 1; y ++ ) {
+			indices.all.set(
+				rowIndices.map(( value ) => value + heightmapWidth * y ),
+				rowIndices.length * y
+			);
+		}
+		//----------------------------------------------------------------------
+		//東西南北橋端用
+		for ( let i = 0; i < heightmapWidth; i ++ ) {
+			indices.north.push( i );
+			indices.south.push( i + heightmapWidth * ( heightmapWidth - 1 ));
+			indices.west.push( i * heightmapWidth );
+			indices.east.push( i * heightmapWidth + heightmapWidth - 1 );
+		}
+		//----------------------------------------------------------------------
+		//結果を返す
+		return indices;
+	}
+
+	//**************************************************************************
+	//タイルを要求して標高データを作って返す
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+		@return	mixed	: QuantizedMeshTerrainData or HeightmapTerrainData instance
+	*/
+	async requestTileGeometry ( x, y, level ) {
+		//----------------------------------------------------------------------
+		//キャッシュを探す
+		const cached	= this.cacheObj.get( x, y, level );
+		//----------------------------------------------------------------------
+		//キャッシュの有無で分岐
+		if ( cached !== void( 0 )) {
+			//キャッシュがあればそれを返す
+			return cached;
+		} else {
+			//キャッシュがなければデータを作ってキャッシュし、作ったデータを返す
+			const cache	= await this.createTileGeometry( x, y, level );
+			this.cacheObj.add( x, y, level, cache );
+			return cache;
+		}
+	}
+
+	//**************************************************************************
+	//標高データを作る
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+		@return	mixed	: QuantizedMeshTerrainData or HeightmapTerrainData instance
+	*/
+	async createTileGeometry ( x, y, level ) {
+		//----------------------------------------------------------------------
+		//主タイルに右、下、右下の各タイルを並べたcanvasを作る
+		const tile	= await this.createSynthesizedTile( x, y, level );
+		//----------------------------------------------------------------------
+		//作った結果で分岐
+		if ( tile instanceof HTMLCanvasElement ) {
+			//canvasが返された場合
+			//contextを取得
+			const context	= tile.getContext( '2d' );
+			//context取得成否で分岐
+			if ( context instanceof CanvasRenderingContext2D ) {
+				//取得成功時はterrainを作り標高データを生成して返す
+				const terrain	= this.imageDataToTerrain(
+					context.getImageData( 0, 0, tile.width, tile.height ),
+					this.heightScale
+				);
+				return this.createQuantizedMeshData( x, y, level, terrain );
+			} else {
+				//取得失敗時は空の標高マップを返す
+				return this.emptyHeightmap();
+			}
+		} else {
+			//canvas以外が返された場合は空の標高マップを返す
+			return this.emptyHeightmap();
+		}
+	}
+
+	//**************************************************************************
+	//主、右、下、右下の合成タイルを作る
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+		@return	mixed	: canvas or false
+	*/
+	async createSynthesizedTile ( x, y, level ) {
+		//----------------------------------------------------------------------
+		//主、右、下、右下のタイルを取得するプロミス配列を作る
+		const promises	= [
+			[ 0, 0 ], [ 1, 0 ], [ 0, 1 ], [ 1, 1 ]
+		].map(( value ) => {
+			//ズームレベル0と右端タイルの場合を考慮して取得タイルのx座標を決める
+			const tileX	= level === 0
+			? 0
+			: x + value[0] < 2 ** level
+			? x + value[0]
+			: 0;
+			//タイル取得プロミスを返す
+			return this.fetchTile( tileX, y + value[1], level, this.url );
+		});
+		//----------------------------------------------------------------------
+		//プロミス配列の処理を待って結果を返す
+		return await Promise.all( promises ).then(
+			( values ) => {
+				//主タイル取得成否で分岐
+				if (
+					values[0] instanceof HTMLImageElement
+					|| values[0] instanceof HTMLCanvasElement
+				) {
+					//主タイル（画像）取得成功時
+					//canvasを作る
+					const canvas	= document.createElement( 'canvas' );
+					canvas.width	= canvas.height	= this.tileWidth + 1;
+					//context取得
+					const context	= canvas.getContext( '2d' );
+					//context取得成功時のみ処理
+					if ( context instanceof CanvasRenderingContext2D ) {
+						//4つのタイルの取得結果を走査して処理
+						values.forEach(( value, index ) => {
+							//タイル貼付け位置を決める
+							const x	= ( index % 2 ) * this.tileWidth;
+							const y	= Math.floor( index / 2 ) * this.tileWidth;
+							//タイル取得成功時のみ貼り付け
+							if (
+								value instanceof HTMLImageElement
+								|| value instanceof HTMLCanvasElement
+							) {
+								context.drawImage( value, x, y );
+							}
+						});
+					}
+					//canvasを返す
+					return canvas;
+				} else {
+					//主タイル取得失敗時はfalseを返す
+					return false;
+				}
+			}
+		);
+	}
+
+	//**************************************************************************
+	//タイルを取得する
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+		@param	string	: tile url template
+		@return	promise	: image or false
+	*/
+	fetchTile ( x, y, level, url ) {
+		//----------------------------------------------------------------------
+		//プロミスを返す
+		return new Promise(( resolve ) => {
+			//画像要素を用意
+			const img	= new Image();
+			//CORS設定
+			img.crossOrigin	= 'anonymous';
+			//取得成功時処理：画像要素を返す
+			img.addEventListener( 'load', ( event ) => {
+				resolve( event.target );
+			});
+			//取得失敗時処理：falseを返す
+			img.addEventListener( 'error', () => {
+				resolve( false );
+			});
+			//タイルURLテンプレートにタイル座標を適用して画像を要求する
+			img.src	= url.replace( '{x}', String( x ))
+				.replace( '{y}', String( y ))
+				.replace( '{z}', String( level ));
+		});
+	}
+
+	//**************************************************************************
+	//空（標高値が全て0）のterrainデータを返す
+	/*
+		@return	object	: HeightmapTerrainData instance
+	*/
+	emptyHeightmap () {
+		//----------------------------------------------------------------------
+		//インスタンスを生成して返す
+		return new Cesium.HeightmapTerrainData({
+			buffer: new Uint8Array( 4 ),
+			width: 2,
+			height: 2,
+		});
+	}
+
+	//**************************************************************************
+	//imageDataを間引いてterrainに変換する
+	/*
+		@param	object	: imageData
+		@param	number	: heightScale
+		@return	typed	: optimized terrain data
+	*/
+	imageDataToTerrain ( imageData, scale ) {
+		//----------------------------------------------------------------------
+		//空の型付配列を用意
+		const terrain	= new Float32Array( this.heightmapWidth ** 2 );
+		//----------------------------------------------------------------------
+		//データ採用間隔を決める（この間隔で標高データを間引く）
+		const wInterval	= ( imageData.width - 1 ) / ( this.heightmapWidth - 1 );
+		const hInterval	= ( imageData.height - 1 ) / ( this.heightmapWidth - 1 );
+		//----------------------------------------------------------------------
+		//imageDataを走査
+		for ( let y = 0; y < this.heightmapWidth; y ++ ) {
+			//取得元のy座標
+			const srcY	= Math.round( y * hInterval );
+			for ( let x = 0; x < this.heightmapWidth; x ++ ) {
+				//取得元のx座標
+				const srcX	= Math.round( x * wInterval );
+				//取得元のインデックス値（rgba4要素で4倍）
+				const index	= ( srcY * imageData.width + srcX ) * 4;
+				//rgba配列を取得
+				const rgba	= imageData.data.slice( index, index + 4 );
+				//terrainに標高値をセット
+				terrain[ y * this.heightmapWidth + x ]	= this.rgbaToHeight(
+					rgba, scale
+				);
+			}
+		}
+		//----------------------------------------------------------------------
+		//結果を返す
+		return terrain;
+	}
+
+	//**************************************************************************
+	//rgba配列から標高を求める
+	/*
+		@param	typed	: typed rgba
+		@param	number	: heightScale
+		@return	number	: elevation
+	*/
+	rgbaToHeight ( rgba, scale ) {
+		//----------------------------------------------------------------------
+		//符号付きでピクセル値を計算
+		const value	= rgba[0] * 65536 + rgba[1] * 256 + rgba[2] - (
+			rgba[0] < 128 ? 0 : 16777216
+		);
+		//----------------------------------------------------------------------
+		//無効値を0にして、スケールを乗じて返す
+		return (
+			rgba[3] === 0 || value === this.heightInvalidValue ? 0 : value
+		) * scale;
+	}
+
+	//**************************************************************************
+	//terrainを量子化して返す
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+		@param	typed	: terrain data
+		@return	object	: QuantizedMeshTerrainData or HeightmapTerrainData instance
+	*/
+	createQuantizedMeshData ( x, y, level, terrain ) {
+		//----------------------------------------------------------------------
+		//省略名を決めておく
+		const size	= this.heightmapWidth;
+		const R	= this.ellipsoid.maximumRadius;
+		//----------------------------------------------------------------------
+		//量子化時の最大値（最小値は0）
+		const quantizedMax	= 32767;
+		//----------------------------------------------------------------------
+		//タイルレクタングルを作る
+		const rectangle	= this.tilingScheme.tileXYToRectangle( x, y, level );
+		//----------------------------------------------------------------------
+		//タイル幅（ラジアン換算）が設定値より大きい（距離が遠い）場合は空のterrainデータを返す
+		if (
+			Number.isFinite( this.zeroRectangleLimit )	//falseでないことの確認
+			&& rectangle.width > Number( this.zeroRectangleLimit )
+		) {
+			// return this.emptyHeightmap( size );
+			return this.emptyHeightmap();
+		}
+		//----------------------------------------------------------------------
+		//法線ベクトルを使用しない場合はHeightmapTerrainDataのインスタンスを生成して返す
+		if ( !this.hasVertexNormals ) {
+			return new Cesium.HeightmapTerrainData({
+				buffer: terrain,
+				width: size,
+				height: size,
+			});
+		}
+		//----------------------------------------------------------------------
+		//幾何学的誤差からスカート長を決める
+		const error	= this.getLevelMaximumGeometricError( level );
+		const skirtHeight	= error * 5;
+		//----------------------------------------------------------------------
+		//標高値の最小と最大を決める
+		const minimumHeight	= Math.min.apply( this, Array.from( terrain ));
+		const maximumHeight	= Math.max.apply( this, Array.from( terrain ));
+		//----------------------------------------------------------------------
+		//量子化用の係数を決める
+		const factor	= quantizedMax / ( size - 1 );
+		//----------------------------------------------------------------------
+		//xyを格納する型付配列を用意
+		const xValues	= new Uint16Array( size ** 2 );
+		const yValues	= new Uint16Array( size ** 2 );
+		//----------------------------------------------------------------------
+		//xyをそれぞれ0から32767の範囲で量子化して格納
+		for ( let i = 0; i < size; i ++ ) {
+			xValues.set(
+				new Uint16Array( size ).map(( value, index ) => index * factor ),
+				i * size
+			);
+			yValues.set(
+				new Uint16Array( size ).fill(( size - 1 - i ) * factor ),
+				i * size
+			);
+		}
+		//----------------------------------------------------------------------
+		//標高値の最小と最大の差を決めて、terrainを量子化
+		const subtraction	= maximumHeight - minimumHeight;
+		const levelValues	= new Uint16Array(
+			terrain.map(( value ) => {
+				return ( value - minimumHeight ) / subtraction * quantizedMax
+			})
+		);
+		//----------------------------------------------------------------------
+		//xyと標高値の量子化結果用の変数を作って結果を格納
+		const quantizedVertices	= new Uint16Array(
+			xValues.length + yValues.length + levelValues.length
+		);
+		[ xValues, yValues, levelValues ].reduce(( acc, cur ) => {
+			quantizedVertices.set( cur, acc );
+			return acc + cur.length;
+		}, 0 );
+		//----------------------------------------------------------------------
+		//タイルレクタングルからhorizonOcclusionPoint（水平線との咬合点）を求める
+		const tileCenter	= Cesium.Cartographic.toCartesian(
+			Cesium.Rectangle.center( rectangle )
+		);
+		const cosWidth	= Math.cos( rectangle.width / 2 );
+		const occlusionHeight	= ( 1 + maximumHeight / R ) / cosWidth;
+		const scaledCenter	= Cesium.Ellipsoid.WGS84.transformPositionToScaledSpace(
+			tileCenter
+		);
+		const horizonOcclusionPoint	= new Cesium.Cartesian3(
+			scaledCenter.x,
+			scaledCenter.y,
+			occlusionHeight
+		);
+		//----------------------------------------------------------------------
+		//orientedBoundingBox、boundingSphereを決める
+		const orientedBoundingBox	= rectangle.width < Cesium.Math.PI_OVER_TWO + Cesium.Math.EPSILON5
+		? Cesium.OrientedBoundingBox.fromRectangle( rectangle, minimumHeight, maximumHeight )
+		: void( 0 );
+		const boundingSphere	= orientedBoundingBox === void( 0 )
+		// ? new Cesium.BoundingSphere( Cesium.Cartesian3.ZERO, 6379792.481506292 )
+		? new Cesium.BoundingSphere( Cesium.Cartesian3.ZERO, R )
+		: Cesium.BoundingSphere.fromOrientedBoundingBox( orientedBoundingBox );
+		//----------------------------------------------------------------------
+		//頂点法線ベクトルを格納する変数を用意
+		const encodedNormals = new Uint8Array( size ** 2 * 2 );
+		//頂点を走査
+		for ( let y = 0; y < size; y ++ ) {
+			const lat	= rectangle.north * ( 1 - y / size ) + rectangle.south * y / size;
+			const sinLat	= Math.sin( lat );
+			const cosLat	= Math.cos( lat );
+			const nz0		= R * 2 * Math.PI / Math.pow( 2, level ) / size * cosLat;
+			for ( let x = 0; x < size; x ++ ) {
+				const index	= y * size + x;
+				const nx	= ( x === size - 1 )
+				? terrain[ index - 1 ] - terrain[ index ]
+				: terrain[ index ] - terrain[ index + 1 ];
+				const ny	= ( y === size - 1 )
+				? terrain[ index ] - terrain[ index - size ]
+				: terrain[ index + size ] - terrain[ index ];
+				//法線ベクトル（nx、ny、nz）の回転行列計算
+				//第1回転：xを回転軸としてPI/2 - lat回転
+				//第2回転：Z=zを回転軸としてlng回転
+				const lng	= rectangle.west * ( 1 - x / size ) + rectangle.east * x / size;
+				const sinLng	= Math.sin( lng );
+				const cosLng	= Math.cos( lng );
+				const rotate	= [
+					 cosLng, sinLat * sinLng, -cosLat * sinLng,
+					-sinLng, sinLat * cosLng, -cosLat * cosLng,
+					 0,      cosLat,           sinLat
+				];
+				//法線ベクトル（nx、ny、nz）を回転する
+				const normalZ	=                  ny * rotate[7] + nz0 * rotate[8];
+				const normalX	= nx * rotate[0] + ny * rotate[1] + nz0 * rotate[2];
+				const normalY	= nx * rotate[3] + ny * rotate[4] + nz0 * rotate[5];
+				//oct encoding
+				const w	= Math.abs( normalX ) + Math.abs( normalY ) + Math.abs ( normalZ );
+				const octEncoded	= {
+					octX	: normalX / w,
+					octY	: normalY / w
+				};
+				const { octX, octY }	= octEncoded;
+				if ( normalZ <= 0 ) {
+					octEncoded.octX	= ( octX >= 0 ? 1 : -1 ) * ( 1 - Math.abs( octY ));
+					octEncoded.octY	= ( octY >= 0 ? 1 : -1 ) * ( 1 - Math.abs( octX ));
+				}
+				//格納
+				encodedNormals[ index * 2 ]	= ( octEncoded.octX + 1 ) * 127.5;
+				encodedNormals[ index * 2 + 1 ]	= ( octEncoded.octY + 1 ) * 127.5;
+			}
+		}
+		//----------------------------------------------------------------------
+		//QuantizedMeshTerrainDataのインスタンスを生成して返す
+		return new Cesium.QuantizedMeshTerrainData({
+			minimumHeight,
+			maximumHeight,
+			quantizedVertices,
+			indices: this.indices.all,
+			boundingSphere,
+			orientedBoundingBox,
+			horizonOcclusionPoint,
+			northIndices: this.indices.north,
+			southIndices: this.indices.south,
+			westIndices: this.indices.west,
+			eastIndices: this.indices.east,
+			northSkirtHeight: skirtHeight,
+			southSkirtHeight: skirtHeight,
+			westSkirtHeight: skirtHeight,
+			eastSkirtHeight: skirtHeight,
+			childTileMask: 15,
+			encodedNormals
+		});
+	}
+
+	//**************************************************************************
+	//幾何学的誤差の推定値取得
+	/*
+		@param	number	: zoom level
+	*/
+	getLevelMaximumGeometricError ( level ) {
+		return Cesium.TerrainProvider.getEstimatedLevelZeroGeometricErrorForAHeightmap(
+			this.tilingScheme.ellipsoid,
+			this.heightmapWidth,
+			this.tilingScheme.getNumberOfXTilesAtLevel( 0 )
+		) / ( 1 << level );
+	}
+
+	//**************************************************************************
+	//タイルの有効性確認
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+	*/
+	getTileDataAvailable ( x, y, level ) {
+		//----------------------------------------------------------------------
+		//シームレス標高タイルの場合
+		//海陸両方を網羅するのはズームレベル9以下
+		//陸を網羅するのはズームレベル14以下
+		//地理院タイルの場合陸を網羅するのはズームレベル14以下（海はすべて無効値）
+		return level <= this.maximumLevel;
+	}
+
+	//**************************************************************************
+	//未使用メソッド（インターフェイスで定義）
+	/*
+		@param	number	: x coordinate for tile
+		@param	number	: y coordinate for tile
+		@param	number	: zoom level for tile
+	*/
+	loadTileDataAvailability ( x, y, level ) {
+		return void( 0 );
+	}
+};

--- a/docs/index.html
+++ b/docs/index.html
@@ -152,10 +152,12 @@ if (!viewrect) {
   });
 }
 
+const tilesetHeightOffset = +urlParams.get('tilesetHeightOffset');
 const tileset = urlParams.get('tileset');
 if (tileset === 'none') {
 } else if (tileset === 'google3dtile') {
   Cesium.createGooglePhotorealistic3DTileset().then(t => {
+    setTilesetHeightOffset(t, tilesetHeightOffset);
     viewer.scene.primitives.add(t);
   }).catch(console.error);
 } else {
@@ -174,6 +176,7 @@ if (tileset === 'none') {
   ).then(tilesets => {
     tilesets.forEach(t => {
       t.imageBasedLighting.luminanceAtZenith = 0.5;
+      setTilesetHeightOffset(t, tilesetHeightOffset);
       bldg3dtiles.add(t);
     });
     viewer.scene.primitives.add(bldg3dtiles);
@@ -181,6 +184,18 @@ if (tileset === 'none') {
       viewer.flyTo(tilesets[0]);
     }
   }).catch(console.error);
+}
+
+function setTilesetHeightOffset(tileset, heightOffset) {
+  if (!heightOffset) {
+    return;
+  }
+  // from Example in CesiumJS API ref-doc
+  const cartographic = Cesium.Cartographic.fromCartesian(tileset.boundingSphere.center);
+  const surface = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, 0.0);
+  const offset = Cesium.Cartesian3.fromRadians(cartographic.longitude, cartographic.latitude, heightOffset);
+  const translation = Cesium.Cartesian3.subtract(offset, surface, new Cesium.Cartesian3());
+  tileset.modelMatrix = Cesium.Matrix4.fromTranslation(translation);
 }
 
 const czmlurl = urlParams.get('czmlurl');

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,9 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
     crossorigin=""></script>
+  <!-- https://github.com/aistairc/gsj_numerical_png_terrain_provider -->
+  <script src="NumericalPngTerrainProvider.js"></script>
+  <script src="ExtendedNumericalPngTerrainProvider.js"></script>
 </head>
 <style>
   #cesiumContainer {
@@ -76,6 +79,15 @@ if (viewrect) {
 Cesium.Camera.DEFAULT_VIEW_FACTOR = 0;
 
 const terrainViewModels = Cesium.createDefaultTerrainProviderViewModels();
+terrainViewModels.push(new Cesium.ProviderViewModel({
+  name: 'GSJ Terrain',
+  tooltip: 'GSJ Terrain',
+  iconUrl: 'https://gbank.gsj.jp/favicon.ico',
+  category: 'Other',
+  creationFunction: function () {
+    return new ExtendedNumericalPngTerrainProvider({useGeoid: true});
+  }
+}));
 const token = urlParams.get('token');
 if (token) {
   Cesium.Ion.defaultAccessToken = token;


### PR DESCRIPTION
## 概要
* [gsj_numerical_png_terrain_provider](https://github.com/aistairc/gsj_numerical_png_terrain_provider) を追加。
* 建物等のtilesetの高さ調整用オフセット値向けのURLパラメータtilesetHeightOffsetを追加。

## 背景
* Cesium ionに追加された、[Japan 3D Buildings](https://cesium.com/blog/2024/06/03/japan-3d-buildings/) を使えば、
  この1つだけをtilesetとして指定すれば良くなる。(対象とする場所に応じたtilesetのURLを指定する必要がなくなる)。
  * 使用するには、Japan 3D BuildingsをCesium ionアカウント側に追加してasset Idを指定する形になる。
  * PLATEAU streamingのterrain用のCesium ion用tokenと同時利用ができない。
  * Cesium World Terrainは都市内でも起伏が大きく、地表付近の視点では実際との違いが大きくて見づらい:
![cesiumWorldTerrain_Japan3DBuildings](https://github.com/deton/CzmlFirstPersonPlayer/assets/761487/003a292d-b706-41a6-a2a5-019fd73b0de4)

## 目的
* Japan 3D Buildingsと組み合わせて使えるように、gsj_numerical_png_terrainを追加。

## 結果
* Japan 3D Buildingsとgsj_numerical_png_terrainの組み合わせでは、建物が地表から浮いて表示される。
* Japan 3D BuildingsはCesium World Terrainの高さに合わせられているようなので、均一に高さを変えてもgsj_numerical_png_terrainと高さが合わない。
  * 画面右側の建物は沈んでいる一方で、画面左側の建物は浮いている。
    `setTilesetHeightOffset(bldg3dtiles.get(0), -12);`
![gsjTerrain_Japan3DBuildings](https://github.com/deton/CzmlFirstPersonPlayer/assets/761487/f1d6e778-a336-40b9-8dfd-248b1d069195)

## 参考
* PLATEAU Terrainとダウンロードした3Dタイル使用時
![PlateauTerrain_tileseturl](https://github.com/deton/CzmlFirstPersonPlayer/assets/761487/b8233fc6-fbd4-4f96-81ea-9b3bbdd7c7e0)

* Cesium World Terrainとダウンロードした3Dタイル使用時
![cesiumWorldTerrain_tileseturl](https://github.com/deton/CzmlFirstPersonPlayer/assets/761487/d225ea7d-f25e-4f9a-93a9-4c85bf78393c)
